### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Alessio Leoncini
 sentence=A library to enable esp8266 platform to send and receive ping messages. 
 paragraph=Present library defines a 'Pinger' class that allows access to low level LWIP functions. It accepts IP addresses as well as DNS names, handles ICMP echo requests and responses allowing some packet customizations, and provides statistics on ping results.
 category=Communication
-url=technologytourist.com
+url=http://technologytourist.com
 architectures=esp8266
 includes=Pinger.h,PingerResponse.h

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Alessio Leoncini
 sentence=A library to enable esp8266 platform to send and receive ping messages. 
 paragraph=Present library defines a 'Pinger' class that allows access to low level LWIP functions. It accepts IP addresses as well as DNS names, handles ICMP echo requests and responses allowing some packet customizations, and provides statistics on ping results.
 category=Communication
-url=http://technologytourist.com
+url=https://www.technologytourist.com
 architectures=esp8266
 includes=Pinger.h,PingerResponse.h


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.